### PR TITLE
BBSRE-7271 fixed LimitNOFILE flag

### DIFF
--- a/templates/init/RedHat/systemd.erb
+++ b/templates/init/RedHat/systemd.erb
@@ -12,7 +12,7 @@ Type=forking
 ExecStart=<%= @executable %> -c <%= @config_file %>
 ExecReload=<%= @executable_ctl %> reload
 ExecStop=<%= @executable_ctl %> shutdown
-LimitNOFile=<%= @minfds %>
+LimitNOFILE=<%= @minfds %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
this change should fix 

` [/etc/systemd/system/supervisord.service:15] Unknown lvalue 'LimitNOFile' in section 'Service'`
